### PR TITLE
Fixed example code in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,8 @@ Usage
 The API lives in the `Xlib` namespace.
 
 ```ruby
+require 'xlib'
+
 display_pointer = Xlib.XOpenDisplay(':0')
 display = Xlib::Display.new(display_pointer)
 
@@ -29,13 +31,12 @@ screens = (0..display[:nscreens]-1).map do |number|
 end
 
 root_windows = screens.map do |screen|
-  Xlib.XRootWindowOfScreen(screen.pointer)
+  Xlib.XRootWindowOfScreen(screen)
 end
 
 root_window_sizes = root_windows.map do |root_win|
   attributes = Xlib::WindowAttributes.new
-  Xlib.XGetWindowAttributes(display.pointer, root_win.pointer, attributes.
-    pointer)
+  Xlib.XGetWindowAttributes(display, root_win, attributes)
   { width: attributes[:width], height: attributes[:height] }
 end
 ```


### PR DESCRIPTION
Before this fix, the example code in the "Usage" section raises ``` undefined method `pointer` ``` error.

```ruby
$ ruby usage.rb
[DEPRECATION] Struct layout is already defined for class Xlib::XSpanFix. Redefinition as in /home/sangenya/dev/trash/xhoge/vendor/bundle/ruby/2.6.0/gems/xlib-1.2.0/lib/xlib/extensions/xrender/struct/trap.rb:11:in `<class:XSpanFix>' will be disallowed in ffi-2.0.
Traceback (most recent call last):
        2: from hoge.rb:15:in `<main>'
        1: from hoge.rb:15:in `map'
hoge.rb:17:in `block in <main>': undefined method `pointer' for 1878:Integer (NoMethodError)
```

After this fix, it runs.

```ruby
$ ruby usage.rb
[DEPRECATION] Struct layout is already defined for class Xlib::XSpanFix. Redefinition as in /home/sangenya/dev/trash/xhoge/vendor/bundle/ruby/2.6.0/gems/xlib-1.2.0/lib/xlib/extensions/xrender/struct/trap.rb:11:in `<class:XSpanFix>' will be disallowed in ffi-2.0.
```

In addition to fixing ``` undefined method `pointer` ```, I added `require 'xlib'`.